### PR TITLE
Fix build on modern Rust; declare wing_node_data_get_id in header

### DIFF
--- a/libwing.h
+++ b/libwing.h
@@ -84,6 +84,7 @@ void               wing_console_destroy                           (WingConsole* 
 WingResponseType   wing_response_get_type                         (const Response* handle);
 void               wing_response_destroy                          (Response* handle);
 
+int32_t            wing_node_data_get_id                          (const Response* handle); // id of the changed node (0 if response is not node-data)
 const char*        wing_node_data_get_string                      (const Response* handle); // Return value must be free by wing_string_destroy()
 float              wing_node_data_get_float                       (const Response* handle);
 int                wing_node_data_get_int                         (const Response* handle);

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -62,7 +62,7 @@ pub extern "C" fn wing_discover_count(handle: *const WingDiscoveryInfoHandle) ->
 #[no_mangle]
 pub extern "C" fn wing_discover_get_ip(handle: *const WingDiscoveryInfoHandle, index: c_int) -> *const c_char {
     unsafe {
-        let info = &(*handle).info[index as usize];
+        let info = &(&(*handle).info)[index as usize];
         CString::new(&info.ip[..]).unwrap().into_raw()
     }
 }
@@ -70,7 +70,7 @@ pub extern "C" fn wing_discover_get_ip(handle: *const WingDiscoveryInfoHandle, i
 #[no_mangle]
 pub extern "C" fn wing_discover_get_name(handle: *const WingDiscoveryInfoHandle, index: c_int) -> *const c_char {
     unsafe {
-        let info = &(*handle).info[index as usize];
+        let info = &(&(*handle).info)[index as usize];
         CString::new(&info.name[..]).unwrap().into_raw()
     }
 }
@@ -78,7 +78,7 @@ pub extern "C" fn wing_discover_get_name(handle: *const WingDiscoveryInfoHandle,
 #[no_mangle]
 pub extern "C" fn wing_discover_get_model(handle: *const WingDiscoveryInfoHandle, index: c_int) -> *const c_char {
     unsafe {
-        let info = &(*handle).info[index as usize];
+        let info = &(&(*handle).info)[index as usize];
         CString::new(&info.model[..]).unwrap().into_raw()
     }
 }
@@ -86,7 +86,7 @@ pub extern "C" fn wing_discover_get_model(handle: *const WingDiscoveryInfoHandle
 #[no_mangle]
 pub extern "C" fn wing_discover_get_serial(handle: *const WingDiscoveryInfoHandle, index: c_int) -> *const c_char {
     unsafe {
-        let info = &(*handle).info[index as usize];
+        let info = &(&(*handle).info)[index as usize];
         CString::new(&info.serial[..]).unwrap().into_raw()
     }
 }
@@ -94,7 +94,7 @@ pub extern "C" fn wing_discover_get_serial(handle: *const WingDiscoveryInfoHandl
 #[no_mangle]
 pub extern "C" fn wing_discover_get_firmware(handle: *const WingDiscoveryInfoHandle, index: c_int) -> *const c_char {
     unsafe {
-        let info = &(*handle).info[index as usize];
+        let info = &(&(*handle).info)[index as usize];
         CString::new(&info.firmware[..]).unwrap().into_raw()
     }
 }


### PR DESCRIPTION
Two small fixes found while building `libwing` against current toolchains for a C#/FFI project.

### 1. Build fails on modern Rust (1.9x)
Recent Rust promotes *"implicit autoref creates a reference to the dereference of a raw pointer"* to a **hard error**, so the `wing_discover_*` getters no longer compile:

```
error: implicit autoref creates a reference to the dereference of a raw pointer
  --> src/ffi.rs:65
   |   let info = &(*handle).info[index as usize];
```

Fixed (5 sites) by making the reference explicit — no behavioural change:
```rust
let info = &(&(*handle).info)[index as usize];
```

### 2. `wing_node_data_get_id` missing from `libwing.h`
The function is implemented and exported in `src/ffi.rs`, but absent from the header — so C/FFI consumers cannot correlate a `NodeData` response to its node id (the Rust `read()` returns `NodeData(id, data)`, but the C header only exposed `get_id` on definitions). Added the declaration.

Both changes are minimal and self-contained. Thanks for libwing — it is a great foundation. 